### PR TITLE
removed binary search from email

### DIFF
--- a/app/controllers/devise_token_auth/concerns/resource_finder.rb
+++ b/app/controllers/devise_token_auth/concerns/resource_finder.rb
@@ -22,7 +22,7 @@ module DeviseTokenAuth::Concerns::ResourceFinder
   def find_resource(field, value)
     @resource = if resource_class.try(:connection_config).try(:[], :adapter).try(:include?, 'mysql')
                   # fix for mysql default case insensitivity
-                  resource_class.where("BINARY #{field} = ? AND provider= ?", value, provider).first
+                  resource_class.where("#{field} = ? AND provider= ?", value, provider).first
                 else
                   resource_class.dta_find_by(field => value, 'provider' => provider)
                 end


### PR DESCRIPTION
Removed BINARY from `email` on the user's table.

We don't need to perform a BINARY search on that field, since we defined on our `initializer/devise.rb` -> `config.case_insensitive_keys = [ :email ]`

QUERY
- ```  User Load (919.3ms)  SELECT  `users`.* FROM `users` WHERE (BINARY email = 'j0a0.silva.kle@gmail.com' AND provider= 'email') ORDER BY firstname ASC LIMIT 1```